### PR TITLE
fix: 랜딩페이지 타이틀/소개글/og-tag문구 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
   <meta property="og:type" content="website">
   <meta property="og:title" content="도기보기 - 반려동물 CCTV">
-  <meta property="og:description" content="우리집 반려동물과 소통하는 새로운 방법, 도기보기">
+  <meta property="og:description" content="스마트폰 공기계를 스마트한 펫CCTV로">
   <meta property="og:image" content="https://dogibogi.co.kr/img/og-image.png">
   <meta property="og:url" content="https://dogibogi.co.kr">
 

--- a/index.html
+++ b/index.html
@@ -5,16 +5,17 @@
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="도기보기 - 반려동물 CCTV">
+  <meta name="description" content="스마트폰 공기계를 스마트한 펫CCTV로! 실시간 영상보기, AI 행동 감지 녹화, 행동분석 리포트 등 다양한 기능을 무료로 간편하게!">
+  <meta name="keywords" content="도기보기, 반려동물, 펫, 무료, cctv, 홈캠, 공기계, 펫cctv, 공기계cctv, 무료cctv">
   <meta name="author" content="petpeotalk">
   <meta name="naver-site-verification" content="8714596cbcd20950a92cf2042ee493e848dc1779" />
 
-  <title>도기보기 - 반려동물 CCTV</title>
+  <title>도기보기 - No.1 AI 행동분석 펫 CCTV</title>
 
   <link rel="shortcut icon" href="favicon.ico?v=2">
 
   <meta property="og:type" content="website">
-  <meta property="og:title" content="도기보기 - 반려동물 CCTV">
+  <meta property="og:title" content="도기보기 - No.1 AI 행동분석 펫 CCTV">
   <meta property="og:description" content="스마트폰 공기계를 스마트한 펫CCTV로">
   <meta property="og:image" content="https://dogibogi.co.kr/img/og-image.png">
   <meta property="og:url" content="https://dogibogi.co.kr">


### PR DESCRIPTION
## 1. 개요
> ### **1.1 타이틀 및 소개글**

![스크린샷 2022-03-08 오전 10 57 24](https://user-images.githubusercontent.com/81014501/157150821-bdab934e-1015-443f-8fb4-1487ded223d7.png)
- 현재 포털사이트에 검색했을때 나오는 서비스명과, 소개글 수정이 필요함

> ### **1.2 og-tag 타이틀 및 문구**
<img width="842" alt="스크린샷 2022-03-07 오후 2 46 36" src="https://user-images.githubusercontent.com/81014501/156975260-d3143ac2-5ea3-4616-a10e-fee976f4cb24.png">

- 현재 슬랙과 카톡에 랜딩페이지 주소를 올렸을 때 나오는 설명
-> 우리집 반려동물과 소통하는 새로..와 같이 문구가 짤리는 문제가 발견됨







## 2. 구현

 

> ### **2.1 타이틀 및 소개글**

- 타이틀 : "도기보기 - 반려동물 CCTV" 
-> **"도기보기 - No.1 AI 행동분석 펫 CCTV"**
- 소개글 : "도기보기 - 반려동물 CCTV" 
->**"스마트폰 공기계를 스마트한 펫CCTV로! 실시간 영상보기, AI 행동 감지 녹화, 행동분석 리포트 등 다양한 기능을 무료로!"**


> ### **2.2 og-tag 타이틀 및 문구**

- 타이틀 : "도기보기 - 반려동물 CCTV" 
-> **"도기보기 - No.1 AI 행동분석 펫 CCTV"**
- 문구 : "우리집 반려동물과 소통하는 새로운 방법, 도기보기" 
-> **"스마트폰 공기계를 스마트한 펫CCTV로"**


> ### **2.3 keywords**
- 도기보기, 반려동물, 펫, 무료, cctv, 홈캠, 공기계, 펫cctv, 공기계cctv, 무료cctv

